### PR TITLE
Version 2.3.0 build 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,8 @@ requirements:
     - pip
     - python >=3.6
     - poetry-core >=1.0.0
+    - setuptools
+    - wheel
   run:
     - python >=3.6
 
@@ -41,8 +43,6 @@ about:
   license_file: LICENSE.txt
   doc_url: https://github.com/jgosmann/pylint-venv/
   dev_url: https://github.com/jgosmann/pylint-venv/
-
-
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 3594955502fdee83c98bfcc8c14cd615e6c7c3608aea525df84853ce79f296bf
 
 build:
-  number: 1
+  number: 0
   skip: True # [py<36]
   script: {{ PYTHON }} -m pip install . -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 3594955502fdee83c98bfcc8c14cd615e6c7c3608aea525df84853ce79f296bf
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,7 @@ about:
       Pylint does not respect the currently activated virtualenv if it is not installed in every virtual environment individually. 
       This module provides a Pylint init-hook to use the same Pylint installation with different virtual environments.
   license: MIT
+  license_family: MIT
   license_file: LICENSE.txt
   doc_url: https://github.com/jgosmann/pylint-venv/
   dev_url: https://github.com/jgosmann/pylint-venv/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,18 +12,18 @@ source:
 
 build:
   number: 1
-  noarch: python
+  skip: True # [py<36]
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
     - poetry-core >=1.0.0
     - setuptools
     - wheel
   run:
-    - python >=3.6
+    - python
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,10 +34,13 @@ test:
 about:
   home: https://github.com/jgosmann/pylint-venv/
   summary: pylint-venv provides a Pylint init-hook to use the same Pylint installation with different virtual environments.
+  description: |
+      Pylint does not respect the currently activated virtualenv if it is not installed in every virtual environment individually. 
+      This module provides a Pylint init-hook to use the same Pylint installation with different virtual environments.
   license: MIT
   license_file: LICENSE.txt
   doc_url: https://github.com/jgosmann/pylint-venv/
-
+  dev_url: https://github.com/jgosmann/pylint-venv/
 
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,10 @@ about:
   summary: pylint-venv provides a Pylint init-hook to use the same Pylint installation with different virtual environments.
   license: MIT
   license_file: LICENSE.txt
+  doc_url: https://github.com/jgosmann/pylint-venv/
+
+
+
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
# Initial 2.3.0 build

Pylint-venv 2.3.0 is a required dependency for spyder 2.4.1

## Changes
- bumped build number
- added doc url
- adding dev url
- adding setup tools and wheel

## Package Info
- upstream repo: https://github.com/jgosmann/pylint-venv/
- Jira ticket: https://anaconda.atlassian.net/browse/PKG-974